### PR TITLE
Protocol verifications to reduce denial of service risks

### DIFF
--- a/x/bsonx/bsoncore/bsoncore.go
+++ b/x/bsonx/bsoncore/bsoncore.go
@@ -844,6 +844,9 @@ func readLengthBytes(src []byte) ([]byte, []byte, bool) {
 	if !ok {
 		return nil, src, false
 	}
+	if l < 4 {
+		return nil, src, false
+	}
 	if len(src) < int(l) {
 		return nil, src, false
 	}

--- a/x/bsonx/bsoncore/bsoncore_test.go
+++ b/x/bsonx/bsoncore/bsoncore_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"go.mongodb.org/mongo-driver/bson/bsontype"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/internal/testutil/assert"
@@ -940,6 +941,14 @@ func TestNullBytes(t *testing.T) {
 			NewDocumentBuilder().StartDocument("foobar").AppendDocument("a\x00", []byte("foo")).FinishDocument()
 		}
 		assertBSONCreationPanics(t, createDocFn, invalidKeyPanicMsg)
+	})
+}
+
+func TestInvalidBytes(t *testing.T) {
+	t.Run("read length less than 4 int bytes", func(t *testing.T) {
+		_, src, ok := readLengthBytes([]byte{0x00, 0x00, 0x00, 0x01})
+		assert.False(t, ok, "expected not ok response for invalid length read")
+		assert.Equal(t, 4, len(src), "expected src to contain the size parameter still")
 	})
 }
 

--- a/x/mongo/driver/compression.go
+++ b/x/mongo/driver/compression.go
@@ -111,6 +111,12 @@ func DecompressPayload(in []byte, opts CompressionOpts) (uncompressed []byte, er
 	case wiremessage.CompressorNoOp:
 		return in, nil
 	case wiremessage.CompressorSnappy:
+		len, err := snappy.DecodedLen(in)
+		if err != nil {
+			return nil, fmt.Errorf("error decoding compressed length %v", err)
+		} else if int32(len) != opts.UncompressedSize {
+			return nil, fmt.Errorf("unexpected decompression size, expected %v but got %v", opts.UncompressedSize, len)
+		}
 		uncompressed = make([]byte, opts.UncompressedSize)
 		return snappy.Decode(uncompressed, in)
 	case wiremessage.CompressorZLib:

--- a/x/mongo/driver/compression.go
+++ b/x/mongo/driver/compression.go
@@ -113,7 +113,7 @@ func DecompressPayload(in []byte, opts CompressionOpts) (uncompressed []byte, er
 	case wiremessage.CompressorSnappy:
 		len, err := snappy.DecodedLen(in)
 		if err != nil {
-			return nil, fmt.Errorf("error decoding compressed length %v", err)
+			return nil, fmt.Errorf("decoding compressed length %w", err)
 		} else if int32(len) != opts.UncompressedSize {
 			return nil, fmt.Errorf("unexpected decompression size, expected %v but got %v", opts.UncompressedSize, len)
 		}

--- a/x/mongo/driver/compression_test.go
+++ b/x/mongo/driver/compression_test.go
@@ -41,6 +41,23 @@ func TestCompression(t *testing.T) {
 	}
 }
 
+func TestDecompressFailures(t *testing.T) {
+	t.Run("snappy decompress huge size", func(t *testing.T) {
+		opts := CompressionOpts{
+			Compressor:       wiremessage.CompressorSnappy,
+			UncompressedSize: 100, // reasonable size
+		}
+		// compressed data is twice as large as declared above
+		// in test we use actual compression so that the decompress action would pass without fix (thus failing test)
+		// when decompression starts it allocates a buffer of the defined size, regardless of a valid compressed body following
+		compressedData, err := CompressPayload(make([]byte, opts.UncompressedSize*2), opts)
+		assert.NoError(t, err, "premature error making compressed example")
+
+		_, err = DecompressPayload(compressedData, opts)
+		assert.Error(t, err)
+	})
+}
+
 func BenchmarkCompressPayload(b *testing.B) {
 	payload := func() []byte {
 		buf, err := os.ReadFile("compression.go")


### PR DESCRIPTION
Submitting the PR here for early feedback before I submit this to the parent MongoDB project.

This PR fixes two Denial of Service conditions:
* Commit 1 - `readLengthBytes` requires the 4 bytes for the length to be included.  Previously when reading a document from the wire this could result in a tight loop where an empty struct is appended to a slice repeatedly until the service runs out of memory (both CPU and memory consumption).
* Commit 2 - Fix a condition with Snappy decompression where a large size is encoded in the Snappy compressed / encoded portion of the byte buffers.  This slice is allocated without bounds and can result in quick memory exhaustion.